### PR TITLE
Remove stray semicolon

### DIFF
--- a/Threading/Task/Sample.php
+++ b/Threading/Task/Sample.php
@@ -64,7 +64,7 @@ class Example extends Base
      *
      * @return boolean True upon success, false otherwise
      */
-    public function process(array $params = array());
+    public function process(array $params = array())
     {
         sleep(1);
         echo '[Pid:' . getmypid() . '] Task executed at ' . date('Y-m-d H:i:s') . PHP_EOL;


### PR DESCRIPTION
Stray semicolon in example script. I'm excited to start using this and possibly help expand on it as I use it more.
